### PR TITLE
Extend list of URLs to exclude adding debug headers to

### DIFF
--- a/piez/piez-bg.js
+++ b/piez/piez-bg.js
@@ -58,9 +58,16 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 });
 
 beforeSendCallback = function(details) {
-  if(/^[^:]*:(?:\/\/)?(?:[^\/]*\.)?akamaiapis.net\/.*$/.test(details.url) || /^https:\/\/ac\.akamai\.com\/.*/.test(details.url)) {
+  // URLs to not add headers for, because they don't support ACAO or have known issues with CORS pre-flight
+  if(/^[^:]*:(?:\/\/)?(?:[^\/]*\.)?akamaiapis.net\/.*$/.test(details.url) ||
+     /^https:\/\/ac\.akamai\.com\/.*/.test(details.url) ||
+     // Google Fonts
+     /fonts\.gstatic\.com/.test(details.url) ||
+     // Akamai mPulse
+     /\.go-mpulse\.net/.test(details.url)) {
     return;
   }
+
   if (akamaiDebugHeaderSwitchStateCached === 'ON' && details.url.indexOf('http') != -1) {
     switch(piezCurrentStateCached) {
       case "piez-off":


### PR DESCRIPTION
Stops the extension from adding headers to a few known domains, which have issues with these new headers in CORS mode or don't allow for CORS Pre-Flights

* `fonts.gstatic.com` for Google Fonts
* `.go-mpulse.net` for Akamai mPulse's `config.json` request